### PR TITLE
refactor: Make database drivers optional for easier Docker builds

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -10,6 +10,7 @@ This guide provides a set of test cases and areas for refinement to ensure the A
 -   You have API keys for different roles (as defined in `API_KEYS_ROLES` in `app/app.py`).
 -   You have sample PDF, DOCX, and TXT files for testing ingestion and querying.
 -   You have a tool for making API requests (e.g., `curl`, Postman, or custom scripts). The API docs are available at `http://localhost:8000/docs`.
+-   **For Database Connector Testing**: If you plan to test SQL Server or Oracle connectivity, you must have installed the optional Python packages (`pip install -r requirements-db.txt`) and configured your environment (or Docker image) with the necessary system-level database drivers as detailed in `DEPLOYMENT.MD`. The base application does not include these by default.
 
 ## 2. Test Cases
 

--- a/requirements-db.txt
+++ b/requirements-db.txt
@@ -1,0 +1,2 @@
+pyodbc
+cx_Oracle

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,3 @@ python-docx
 langchain
 pandas
 openpyxl
-pyodbc
-cx_Oracle


### PR DESCRIPTION
This commit addresses potential Docker build failures due to missing system dependencies for `cx_Oracle` and `pyodbc`.

Changes:
- Removed `cx_Oracle` and `pyodbc` from the main `requirements.txt`.
- Added `requirements-db.txt` for these optional database drivers.
- Updated `app/data_connectors.py` to:
  - Conditionally import `cx_Oracle` and `pyodbc`.
  - Print warnings if libraries are not found during application startup.
  - Raise `RuntimeError` with informative messages in database connector functions if the required libraries are not installed.
- Updated `DEPLOYMENT.MD` and `TESTING_GUIDE.MD` to:
  - Clearly state that database drivers are optional.
  - Provide instructions on how you can install these drivers and their system-level dependencies if needed (e.g., by customizing your Dockerfile and using `requirements-db.txt`).
  - Note that the default Docker image will not support these database connections out-of-the-box.

This change ensures a smoother default build experience for you if you do not immediately require SQL Server or Oracle database connectivity, while still providing guidance for those who do.