### PR TITLE
fix: Add python-multipart dependency and update Pydantic schema_extra

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -255,7 +255,7 @@ class QueryRequest(BaseModel):
     top_n: int = 3 # Number of relevant chunks to retrieve
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "query": "What were the main operational issues reported last month?",
                 "top_n": 5,
@@ -271,7 +271,7 @@ class SummarizeRequest(BaseModel):
     max_summary_length: int = 150 # Optional: hint for summary length
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "text": "The quick brown fox jumps over the lazy dog. This sentence is often used to demonstrate all letters of the alphabet. It is a classic pangram. The purpose of this example is to provide a long enough text that might warrant summarization into a shorter form, perhaps focusing on the key subject, which is the pangram itself and its usage.",
                 "max_summary_length": 50,
@@ -287,7 +287,7 @@ class FreeFormPromptRequest(BaseModel):
     # max_tokens: int = 500 # Example if we want to control LLM output length later
 
     class Config:
-        schema_extra = {
+        json_schema_extra = {
             "example": {
                 "prompt": "Explain the concept of a Large Language Model in simple terms.",
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # You can add any libraries your application needs here.
 requests
 fastapi
+python-multipart
 uvicorn[standard]
 ctransformers
 chromadb


### PR DESCRIPTION
This commit addresses two issues identified from your feedback:

1.  **RuntimeError on file upload:** The application was failing to start/handle file uploads because the `python-multipart` library, required by FastAPI for form data (file uploads), was missing from `requirements.txt`. This library has now been added.

2.  **Pydantic V2 UserWarning:** A UserWarning was being emitted due to the use of `schema_extra` in Pydantic model configurations. This has been updated to `json_schema_extra` as per Pydantic V2 standards.

Changes:
- Added `python-multipart` to `requirements.txt`.
- Updated `QueryRequest`, `SummarizeRequest`, and `FreeFormPromptRequest` models in `app/app.py` to use `json_schema_extra` instead of `schema_extra`.

Dockerfile and documentation (`DEPLOYMENT.MD`, `TESTING_GUIDE.MD`) were reviewed and found to require no changes for these specific fixes.