### PR TITLE
fix: Ensure Sentence Transformer model loads from local path for airg…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,21 @@ FROM python:3.10-slim
 # Set the working directory in the container
 WORKDIR /app
 
-# Copy the application directory (app folder) into the container at /app/app
-# This assumes your 'app' directory with app.py, document_processor.py, etc. is in the same directory as this Dockerfile
-COPY ./app /app/app
+# Argument for the host path where the sentence transformer model files are located
+# Users should override this during build: --build-arg HOST_SENTENCE_TRANSFORMER_MODEL_PATH=./path/to/your/model
+# Using a default that might exist locally if users follow a convention.
+ARG HOST_SENTENCE_TRANSFORMER_MODEL_PATH=./local_sentence_transformer_models/all-MiniLM-L6-v2
+
+# Create directories for LLM models, uploads, ChromaDB, and the sentence transformer model target path
+# The target path /app/sentence_transformer_models/all-MiniLM-L6-v2 should match the default in app.py and document_processor.py
+RUN mkdir -p /app/models /app/uploads /app/chroma_db /app/sentence_transformer_models/all-MiniLM-L6-v2
+
+# Copy the pre-downloaded sentence transformer model into the image
+# Ensure HOST_SENTENCE_TRANSFORMER_MODEL_PATH is set during docker build via --build-arg
+# If HOST_SENTENCE_TRANSFORMER_MODEL_PATH is not set or points to a non-existent/empty directory,
+# this COPY command might behave unexpectedly or copy nothing, so it's crucial the user provides a valid path.
+# The trailing slash on the destination ensures the contents of the source directory are copied into the target directory.
+COPY ${HOST_SENTENCE_TRANSFORMER_MODEL_PATH} /app/sentence_transformer_models/all-MiniLM-L6-v2/
 
 # Copy the requirements file into the container at /app
 COPY requirements.txt /app/requirements.txt
@@ -14,9 +26,9 @@ COPY requirements.txt /app/requirements.txt
 # Install any needed packages specified in requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Create directories for models, uploads, and ChromaDB
-# These directories will be used for volume mounting from the host
-RUN mkdir -p /app/models /app/uploads /app/chroma_db
+# Copy the application directory (app folder) into the container at /app/app
+# This assumes your 'app' directory with app.py, document_processor.py, etc. is in the same directory as this Dockerfile
+COPY ./app /app/app
 
 # Make port 8000 available to the world outside this container
 EXPOSE 8000
@@ -30,7 +42,8 @@ CMD ["uvicorn", "app.app:app", "--host", "0.0.0.0", "--port", "8000"]
 # RUN useradd --create-home appuser
 # USER appuser
 # Note: If using a non-root user, ensure file permissions are correctly set 
-# for directories like /app/models, /app/uploads, /app/chroma_db if they need to be writable by the app.
+# for directories like /app/models, /app/uploads, /app/chroma_db and the sentence_transformer_models
+# if they need to be writable by the app (though sentence transformer models are usually read-only at runtime).
 # For simplicity in this exercise, we'll continue as root (default).
 # The CMD would remain the same as it's executed by the current user.
 # The WORKDIR /app also applies to the user.


### PR DESCRIPTION
…apped use

This commit addresses a FileNotFoundError for the Sentence Transformer model when running in an airgapped environment. The `sentence-transformers` library was attempting to download the model at runtime.

Changes:
- Modified `app/document_processor.py` and `app/app.py`:
  - `SentenceTransformerEmbeddingFunction` now initializes using a local model path within the container (e.g., `/app/sentence_transformer_models/all-MiniLM-L6-v2`).
  - This internal path is configurable via the `ENV_SENTENCE_TRANSFORMER_MODEL_PATH` environment variable.
  - Added error handling for initialization failures.
- Updated `Dockerfile`:
  - Added an `ARG HOST_SENTENCE_TRANSFORMER_MODEL_PATH` to specify the location of the pre-downloaded Sentence Transformer model on the host machine.
  - The Dockerfile now copies these model files into the image at the path specified by `ENV_SENTENCE_TRANSFORMER_MODEL_PATH`'s default.
- Updated `DEPLOYMENT.MD`:
  - Added detailed instructions for you to pre-download the `sentence-transformers/all-MiniLM-L6-v2` model.
  - Updated the `docker build` command to show usage of the `--build-arg HOST_SENTENCE_TRANSFORMER_MODEL_PATH`.
  - Clarified the role of the `ENV_SENTENCE_TRANSFORMER_MODEL_PATH` environment variable.

These changes allow the Sentence Transformer model to be included directly in the Docker image, enabling the application to work correctly in environments without internet access.