### PR TITLE
fix: Resolve ImportError for relative imports in app.py under Supervisor

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -9,7 +9,7 @@ import os
 import shutil
 from typing import Dict, List, Optional # Added Optional for clarity, though not strictly needed by the code here
 
-from . import document_processor # Assuming document_processor.py is in the same 'app' directory
+import document_processor # Assuming document_processor.py is in the same 'app' directory
 
 import chromadb
 from chromadb.utils import embedding_functions


### PR DESCRIPTION
This commit fixes an `ImportError: attempted relative import with no known parent package` that occurred when running the FastAPI application under Supervisor. The error was due to Python's handling of relative imports when the working directory is set by Supervisor.

Changes:
- Modified `app/app.py`:
  - Changed the import for `document_processor` from `from . import document_processor` to `import document_processor`.
  - Ensured other local module imports (if any were direct in app.py) would follow this absolute pattern.

The `supervisord.conf` for FastAPI already correctly sets the working directory to `/app/app`, allowing these absolute imports to resolve correctly. Documentation (`DEPLOYMENT.MD`) was reviewed and required no changes for this fix.

This change should allow the FastAPI application to start reliably when managed by Supervisor.