### PR TITLE
fix: Resolve Uvicorn "Could not import module app.app" under Supervisor

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -3,7 +3,7 @@ nodaemon=true ; run supervisord in foreground
 
 [program:fastapi]
 command=/usr/local/bin/uvicorn app.app:app --host 0.0.0.0 --port 8000 --workers 1
-directory=/app/app
+directory=/app
 autostart=true
 autorestart=true
 stderr_logfile=/var/log/supervisor/fastapi_err.log


### PR DESCRIPTION
This commit fixes an error where Uvicorn, when managed by Supervisor, would fail with "ERROR: Error loading ASGI app. Could not import module app.app".

Changes:
1.  **`supervisord.conf`:**
    -   Changed the `directory` for the `[program:fastapi]` section from
        `/app/app` to `/app`.
    -   The Uvicorn command `uvicorn app.app:app ...` now correctly resolves
        `app.app` by looking for the `app` package (directory `/app/app`)
        within the new working directory `/app`.

2.  **`app/__init__.py`:**
    -   Created an empty `app/__init__.py` file. This ensures the
        `app` subdirectory (copied to `/app/app` in the Docker image)
        is treated as a Python package, which is necessary for the
        `app.app` module path to be correctly resolved by Uvicorn
        when its CWD is `/app`.

The Dockerfile's `COPY ./app /app/app` instruction was reviewed and confirmed to correctly include the new `__init__.py` file.